### PR TITLE
fix: GitHub social link

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
       title: 'Astro PlantUML',
       description: 'Documentation and examples for the astro-plantuml integration',
       social: {
-        github: 'https://github.com/yourusername/astro-plantuml',
+        github: 'https://github.com/joesaby/astro-plantuml',
       },
       sidebar: [
         {


### PR DESCRIPTION
#### Description

I noticed that the github social icon doesn't lead to a real GH repo, so I changed the link so it points to the main `astro-plantuml` repo, of course you could also change it to point to the this repo...